### PR TITLE
Add Bitcoin Bottom Score to Analytics and Data Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@
 - **[Dune Analytics](https://dune.com/)** - A platform for querying and visualizing DeFi data.
 - **[DeBank](https://debank.com/)** - An analytics tool providing insights into DeFi portfolios and protocols.
 - **[Token Terminal](https://tokenterminal.com/)** - Provides fundamental analysis of DeFi projects and protocols.
+- **[Bitcoin Bottom Score](https://bitcoinbottom.app)** - Free Bitcoin market cycle bottom probability tracker aggregating 25 on-chain signals (MVRV Z-Score, Puell Multiple, Hash Ribbon, Fear & Greed, etc.) into a daily score.
 
 ## Security and Auditing
 


### PR DESCRIPTION
Adds [Bitcoin Bottom Score](https://bitcoinbottom.app) to the Analytics and Data Tools section.

Bitcoin Bottom Score is a free Bitcoin market cycle bottom probability tracker that aggregates 25 on-chain signals into a daily score. While Bitcoin-focused rather than DeFi-native, it uses many of the same on-chain analytics techniques used in DeFi analysis.