### PR TITLE
Add Web3 Discover to Analytics and Data Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@
 - **[Dune Analytics](https://dune.com/)** - A platform for querying and visualizing DeFi data.
 - **[DeBank](https://debank.com/)** - An analytics tool providing insights into DeFi portfolios and protocols.
 - **[Token Terminal](https://tokenterminal.com/)** - Provides fundamental analysis of DeFi projects and protocols.
+- **[Web3 Discover](https://web3-discover.vercel.app)** - A hand-vetted directory of currently-claimable airdrops and DeFi opportunities; deadline-sorted, every entry "last verified" stamped. No paid listings, no wallet-connect.
 
 ## Security and Auditing
 


### PR DESCRIPTION
Adds [web3-discover](https://web3-discover.vercel.app) — a hand-vetted directory of 42 currently-claimable web3 airdrops.

Why this fits this list:
- Curated (not auto-aggregated); every entry has a chain, cost-floor, risk flag, and a "last verified" date stamp
- No paid listings, no wallet-connect, no JS that touches user funds
- Deadline-sorted; filters by chain / risk / effort / free-to-enter
- Ships a paste-your-wallet eligibility checker, an MCP server (`/api/mcp`), and a public CC0 data mirror at https://github.com/SolvoHQ/web3-discover-data

One-line addition, no schema changes. Happy to drop the entry in a different section if you prefer — just let me know.