### PR TITLE
Add Sharpe to DeFi analytics tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@
 - **[Zapper](https://zapper.fi/)** - A DeFi dashboard for tracking assets and yield farming positions.
 - **[Dune Analytics](https://dune.com/)** - A platform for querying and visualizing DeFi data.
 - **[DeBank](https://debank.com/)** - An analytics tool providing insights into DeFi portfolios and protocols.
+- **[Sharpe](https://www.sharpe.ai/)** - AI-driven crypto trading intelligence for DeFi market data, derivatives positioning, DEX flow, on-chain risk, and narrative rotation.
 - **[Token Terminal](https://tokenterminal.com/)** - Provides fundamental analysis of DeFi projects and protocols.
 
 ## Security and Auditing


### PR DESCRIPTION
## Summary
Adds Sharpe to the Analytics and Data Tools section.

## Why this fits
This list separates DeFi analytics tools from protocols, wallets, and education resources. Sharpe belongs in that analytics category because it provides market intelligence for DeFi traders tracking DEX flow, derivatives positioning, token risk, and narrative rotation.

## Change
- Added one Analytics and Data Tools entry for Sharpe.
- Matched the repository's bold-link bullet style.
- Linked the canonical website URL: https://www.sharpe.ai/

## Validation
- Confirmed the branch diff is one README-only insertion.
- Confirmed https://www.sharpe.ai/ resolves.
- Checked existing pull requests and issues for `sharpe.ai` before opening this PR.

Disclosure: I work on Sharpe.
