### PR TITLE
Add Pharos stablecoin analytics dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@
 - **[Dune Analytics](https://dune.com/)** - A platform for querying and visualizing DeFi data.
 - **[DeBank](https://debank.com/)** - An analytics tool providing insights into DeFi portfolios and protocols.
 - **[Token Terminal](https://tokenterminal.com/)** - Provides fundamental analysis of DeFi projects and protocols.
+- [Pharos](https://pharos.watch/) — Open-source stablecoin analytics dashboard covering peg stress, DEX liquidity, safety scores, blacklist events, mint/burn flows, and stablecoin failures.
 
 ## Security and Auditing
 


### PR DESCRIPTION
Adds [Pharos](https://pharos.watch/) to the **Analytics and Data Tools** section.

Pharos is an open-source stablecoin analytics dashboard tracking 391+ stablecoins. It covers peg stress, DEX liquidity, safety scores, blacklist events, mint/burn flows, and historical stablecoin failures — a useful resource for DeFi researchers and risk analysts.