### PR TITLE
Add YieldScope to Analytics and Data Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@
 - **[Sharpe](https://www.sharpe.ai/)** - AI-driven crypto trading intelligence for DeFi market data, derivatives positioning, DEX flow, on-chain risk, and narrative rotation.
 - **[Token Terminal](https://tokenterminal.com/)** - Provides fundamental analysis of DeFi projects and protocols.
 - [Pharos](https://pharos.watch/) — Open-source stablecoin analytics dashboard covering peg stress, DEX liquidity, safety scores, blacklist events, mint/burn flows, and stablecoin failures.
+- [YieldScope](https://yieldscope.io) — Compares CeFi exchange Earn rates and DeFi pool yields across 12 platforms with A–F risk grades, updated daily via exchange APIs.
 
 ## Security and Auditing
 


### PR DESCRIPTION
Adding YieldScope — a free, daily-synced yield comparison tool (CeFi exchange Earn rates + DeFi pools) with transparent A-F risk grades per platform. No paywall, no listing fees, methodology is public. Entry follows the existing format of the Analytics and Data Tools section.