### PR TITLE
Add Deep Blue Alpha to Analytics and Data Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@
 - **[Sharpe](https://www.sharpe.ai/)** - AI-driven crypto trading intelligence for DeFi market data, derivatives positioning, DEX flow, on-chain risk, and narrative rotation.
 - **[Token Terminal](https://tokenterminal.com/)** - Provides fundamental analysis of DeFi projects and protocols.
 - [Pharos](https://pharos.watch/) — Open-source stablecoin analytics dashboard covering peg stress, DEX liquidity, safety scores, blacklist events, mint/burn flows, and stablecoin failures.
+- **[Deep Blue Alpha](https://deepbluealpha.io/)** - Real-time Ethereum whale wallet tracker — monitors 10,000+ wallets block-by-block, showing net buy/sell flow per token across 1H/24H/7D windows. Free, no signup.
 
 ## Security and Auditing
 


### PR DESCRIPTION
**Deep Blue Alpha** is a free real-time Ethereum whale wallet tracker — monitors 10,000+ wallets block-by-block, surfacing net buy/sell flow per token across 1H/24H/7D windows. No signup required.

- Website: https://deepbluealpha.io/
- Free public API: `/api/top-tokens` and `/api/stats`

Fits alongside Dune, DeBank, and Token Terminal in the Analytics and Data Tools section.