### PR TITLE
Add Ophis (intent-based DEX aggregator)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@
 - **[PancakeSwap](https://pancakeswap.finance/)** - A popular DEX on the Binance Smart Chain, known for its low fees.
 - **[Balancer](https://balancer.fi/)** - A DEX and automated portfolio manager for ERC-20 tokens.
 - **[1inch](https://1inch.io/)** - A DEX aggregator that finds the best rates across multiple DEXs.
+- **[Ophis](https://ophis.fi/)** - An intent-based DEX aggregator (a CoW Protocol fork) for gasless, MEV-protected swaps across 11 chains, with an MCP server and SDK for AI agents.
 
 ## Lending and Borrowing
 


### PR DESCRIPTION
Adds Ophis to the Decentralized Exchanges (DEXs) section.

Ophis is an intent-based DEX aggregator (a CoW Protocol fork) for gasless, MEV-protected swaps across 11 chains, with an MCP server and SDK for AI agents. Site: https://ophis.fi/