### PR TITLE
Add Yieldo to Analytics and Data Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@
 - **[DeBank](https://debank.com/)** - An analytics tool providing insights into DeFi portfolios and protocols.
 - **[Sharpe](https://www.sharpe.ai/)** - AI-driven crypto trading intelligence for DeFi market data, derivatives positioning, DEX flow, on-chain risk, and narrative rotation.
 - **[Token Terminal](https://tokenterminal.com/)** - Provides fundamental analysis of DeFi projects and protocols.
+- **[Yieldo](https://yieldo.me)** - Cross-exchange rates: staking APY, withdrawal fees, live network-freeze status, funding, and arbitrage across CEXs and DEXs.
 - [Pharos](https://pharos.watch/) — Open-source stablecoin analytics dashboard covering peg stress, DEX liquidity, safety scores, blacklist events, mint/burn flows, and stablecoin failures.
 
 ## Security and Auditing


### PR DESCRIPTION
Adds **Yieldo** to *Analytics and Data Tools*.

Yieldo is a free cross-exchange rates aggregator: live staking APY, withdrawal fees with real-time network-availability ("withdrawal freeze") status, funding rates and arbitrage across 11 CEXs and DEXs (incl. STON.fi, Jupiter, and the Hyperliquid perp-DEX). Open JSON/CSV feeds at https://yieldo.me/about/data, no signup.

Single entry, follows the existing `- **[Name](url)** - Description.` format.
