### PR TITLE
Add Cryptool to DeFi tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@
 - **[Zapper](https://zapper.fi/)** - A DeFi dashboard for tracking assets and yield farming positions.
 - **[Dune Analytics](https://dune.com/)** - A platform for querying and visualizing DeFi data.
 - **[DeBank](https://debank.com/)** - An analytics tool providing insights into DeFi portfolios and protocols.
+- **[Cryptool](https://cryptool.io/)** - Non-custodial multi-chain portfolio tracker with built-in fundraising, OTC, and fund management.
 - **[Sharpe](https://www.sharpe.ai/)** - AI-driven crypto trading intelligence for DeFi market data, derivatives positioning, DEX flow, on-chain risk, and narrative rotation.
 - **[Token Terminal](https://tokenterminal.com/)** - Provides fundamental analysis of DeFi projects and protocols.
 - [Pharos](https://pharos.watch/) — Open-source stablecoin analytics dashboard covering peg stress, DEX liquidity, safety scores, blacklist events, mint/burn flows, and stablecoin failures.


### PR DESCRIPTION
Adds Cryptool (https://cryptool.io) to the Analytics and Data Tools list, alongside DeBank, Zapper, and Zerion. Cryptool is a non-custodial, multi-chain portfolio tracker that also covers fundraising, OTC, and fund management in one dashboard. It is useful and relevant, not a duplicate, the link works and is publicly accessible, and it follows the list's quality standards. Single-line addition matching the existing format. Thanks for maintaining the list!