### PR TITLE
Add Deep Blue Alpha to Analytics and Data Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@
 - **[Sharpe](https://www.sharpe.ai/)** - AI-driven crypto trading intelligence for DeFi market data, derivatives positioning, DEX flow, on-chain risk, and narrative rotation.
 - **[Token Terminal](https://tokenterminal.com/)** - Provides fundamental analysis of DeFi projects and protocols.
 - [Pharos](https://pharos.watch/) — Open-source stablecoin analytics dashboard covering peg stress, DEX liquidity, safety scores, blacklist events, mint/burn flows, and stablecoin failures.
+- **[Deep Blue Alpha](https://deepbluealpha.io/)** - Real-time Ethereum whale tracking platform monitoring 42,000+ whale wallets with live DEX trade feeds, buy/sell sentiment scoring, and a free public API. No signup required.
 - **[Deep Blue Alpha](https://deepbluealpha.io/)** - Real-time Ethereum whale wallet tracker — monitors 10,000+ wallets block-by-block, showing net buy/sell flow per token across 1H/24H/7D windows. Free, no signup.
 
 ## Security and Auditing

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@
 - **[Sharpe](https://www.sharpe.ai/)** - AI-driven crypto trading intelligence for DeFi market data, derivatives positioning, DEX flow, on-chain risk, and narrative rotation.
 - **[Token Terminal](https://tokenterminal.com/)** - Provides fundamental analysis of DeFi projects and protocols.
 - [Pharos](https://pharos.watch/) — Open-source stablecoin analytics dashboard covering peg stress, DEX liquidity, safety scores, blacklist events, mint/burn flows, and stablecoin failures.
+- **[Deep Blue Alpha](https://deepbluealpha.io/)** - Real-time Ethereum whale wallet tracker — monitors 10,000+ wallets block-by-block, showing net buy/sell flow per token across 1H/24H/7D windows. Free, no signup.
 
 ## Security and Auditing
 


### PR DESCRIPTION
Adds [Deep Blue Alpha](https://deepbluealpha.io/) to the Analytics and Data Tools section.

**What it does:** Real-time Ethereum whale tracking — monitors 42,000+ whale wallets with live DEX trade feeds, buy/sell sentiment scoring, and conviction-based wallet grading.

**Why it fits this list:**
- Free public API with no signup required ([docs](https://deepbluealpha.io/whale-index))
- Fills a gap for Ethereum-specific whale behavior analytics (the existing tools cover general DeFi, TVL, and multi-chain)
- Active project with daily updates since early 2026

Happy to adjust the description if needed.