### PR TITLE
Add Crypto Tx Classifier API to Analytics and Data Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@
 - **[Sharpe](https://www.sharpe.ai/)** - AI-driven crypto trading intelligence for DeFi market data, derivatives positioning, DEX flow, on-chain risk, and narrative rotation.
 - **[Token Terminal](https://tokenterminal.com/)** - Provides fundamental analysis of DeFi projects and protocols.
 - [Pharos](https://pharos.watch/) — Open-source stablecoin analytics dashboard covering peg stress, DEX liquidity, safety scores, blacklist events, mint/burn flows, and stablecoin failures.
+- **[Crypto Tx Classifier API](https://crypto-tx-classifier-api.onrender.com)** - Classifies raw on-chain DeFi transactions (Curve, Convex, Aerodrome, Across bridge) into labeled categories for tax/accounting import. Free tier, non-custodial on-chain payment, read-only.
 
 ## Security and Auditing
 


### PR DESCRIPTION
Adding Crypto Tx Classifier API to the list.

Disclosure: I'm the maintainer — this is my own project, not a third-party recommendation.

It's a metered API that labels DeFi transactions (swap, LP deposit/withdraw, reward claim, bridge deposit/fill) that generic explorers and tax software typically import as unlabeled transfers. Read-only against public chain data, no custody. Free tier available, no signup friction beyond an email.

Happy to adjust the entry format/wording to match this list's conventions if it doesn't already fit.